### PR TITLE
Fix painting

### DIFF
--- a/lib/text.dart
+++ b/lib/text.dart
@@ -38,7 +38,7 @@ class PostTextPainter extends CustomPainter {
       drawTextInternal(canvas, size, p);
     }
     if (drawBody) {
-      // draw text body
+      // draw text body, use a second paint object here, different from one used for stroke
       fillp.color = textColor;
       fillp.style = PaintingStyle.fill;
       drawTextInternal(canvas, size, fillp);

--- a/lib/text.dart
+++ b/lib/text.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 
 class PostTextPainter extends CustomPainter {
   final Paint p = Paint();
+  final Paint fillp = Paint();
   final Color textColor = Colors.white;
   final double fontSize = 100;
   final TextPainter tp = TextPainter(
@@ -33,25 +34,25 @@ class PostTextPainter extends CustomPainter {
       // draw text stroke
       p.color = Colors.black;
       p.style = PaintingStyle.stroke;
-      p.strokeWidth = 1;
-      drawTextInternal(canvas, size);
+      p.strokeWidth = 3;
+      drawTextInternal(canvas, size, p);
     }
     if (drawBody) {
       // draw text body
-      p.color = textColor;
-      p.style = PaintingStyle.fill;
-      drawTextInternal(canvas, size);
+      fillp.color = textColor;
+      fillp.style = PaintingStyle.fill;
+      drawTextInternal(canvas, size, fillp);
     }
   }
 
-  void drawTextInternal(Canvas canvas, Size size) {
+  void drawTextInternal(Canvas canvas, Size size, Paint paintToUse) {
     tp.text = TextSpan(
       text: "Test",
       style: TextStyle(
         fontSize: fontSize,
         // fontFamily: fontFamily,
         height: 1,
-        foreground: p,
+        foreground: paintToUse,
       ),
     );
     tp.layout(


### PR DESCRIPTION
This change simply adds a second Paint object which is used for the fill operation.

(I also increased the `strokeWidth` to 3 to make it more obvious (once the fill operation is working it)). 

When using a single paint object the object is cached somewhere in the lower level paint operation and the change to the `style` property (and `color`) are not detected.   By using two different paint objects when everything works as expected.