### PR TITLE
Move offset

### DIFF
--- a/lib/text.dart
+++ b/lib/text.dart
@@ -4,7 +4,6 @@ import 'package:flutter/material.dart';
 
 class PostTextPainter extends CustomPainter {
   final Paint p = Paint();
-  final Paint fillp = Paint();  // create a second paint object for fill
   final Color textColor = Colors.white;
   final double fontSize = 100;
   final TextPainter tp = TextPainter(
@@ -34,25 +33,27 @@ class PostTextPainter extends CustomPainter {
       // draw text stroke
       p.color = Colors.black;
       p.style = PaintingStyle.stroke;
-      p.strokeWidth = 3;
-      drawTextInternal(canvas, size, p);
+      p.strokeWidth = 2;
+      drawTextInternal(canvas, size);
     }
     if (drawBody) {
       // draw text body
-      fillp.color = textColor;
-      fillp.style = PaintingStyle.fill;
-      drawTextInternal(canvas, size, fillp);
+      p.color = textColor;
+      p.style = PaintingStyle.fill;
+      drawTextInternal(canvas, size);
     }
   }
 
-  void drawTextInternal(Canvas canvas, Size size, Paint paintToUse) {
+  static int call=0;
+  void drawTextInternal(Canvas canvas, Size size) {
+    call++;
     tp.text = TextSpan(
       text: "Test",
       style: TextStyle(
         fontSize: fontSize,
         // fontFamily: fontFamily,
         height: 1,
-        foreground: paintToUse,
+        foreground: p,
       ),
     );
     tp.layout(

--- a/lib/text.dart
+++ b/lib/text.dart
@@ -4,7 +4,7 @@ import 'package:flutter/material.dart';
 
 class PostTextPainter extends CustomPainter {
   final Paint p = Paint();
-  final Paint fillp = Paint();
+  final Paint fillp = Paint();  // create a second paint object for fill
   final Color textColor = Colors.white;
   final double fontSize = 100;
   final TextPainter tp = TextPainter(

--- a/lib/text.dart
+++ b/lib/text.dart
@@ -44,9 +44,7 @@ class PostTextPainter extends CustomPainter {
     }
   }
 
-  static int call=0;
   void drawTextInternal(Canvas canvas, Size size) {
-    call++;
     tp.text = TextSpan(
       text: "Test",
       style: TextStyle(

--- a/lib/text.dart
+++ b/lib/text.dart
@@ -51,7 +51,7 @@ class PostTextPainter extends CustomPainter {
         fontSize: fontSize,
         // fontFamily: fontFamily,
         height: 1,
-        //overflow:  ? TextOverflow.clip : TextOverflow.ellipsis,
+        //overflow:  (p.style==PaintingStyle.stroke) ? TextOverflow.clip : TextOverflow.ellipsis,
         foreground: p,
       ),
     );

--- a/lib/text.dart
+++ b/lib/text.dart
@@ -51,7 +51,7 @@ class PostTextPainter extends CustomPainter {
         fontSize: fontSize,
         // fontFamily: fontFamily,
         height: 1,
-        overflow: (p.style==PaintingStyle.stroke) ? TextOverflow.clip : TextOverflow.ellipsis,
+        //overflow:  ? TextOverflow.clip : TextOverflow.ellipsis,
         foreground: p,
       ),
     );
@@ -60,7 +60,7 @@ class PostTextPainter extends CustomPainter {
       minWidth: 200,
       maxWidth: 200,
     );
-    tp.paint(canvas, Offset(-100, -100));
+    tp.paint(canvas, (p.style==PaintingStyle.stroke) ? Offset(-100, -100) : Offset(-110, -110));
   }
 
   @override

--- a/lib/text.dart
+++ b/lib/text.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 
 class PostTextPainter extends CustomPainter {
   final Paint p = Paint();
+  final Paint fillp = Paint();
   final Color textColor = Colors.white;
   final double fontSize = 100;
   final TextPainter tp = TextPainter(
@@ -33,25 +34,25 @@ class PostTextPainter extends CustomPainter {
       // draw text stroke
       p.color = Colors.black;
       p.style = PaintingStyle.stroke;
-      p.strokeWidth = 1;
-      drawTextInternal(canvas, size);
+      p.strokeWidth = 3;
+      drawTextInternal(canvas, size, p);
     }
     if (drawBody) {
       // draw text body
-      p.color = textColor;
-      p.style = PaintingStyle.fill;
-      drawTextInternal(canvas, size);
+      fillp.color = textColor;
+      fillp.style = PaintingStyle.fill;
+      drawTextInternal(canvas, size, fillp);
     }
   }
 
-  void drawTextInternal(Canvas canvas, Size size) {
+  void drawTextInternal(Canvas canvas, Size size, Paint paintToUse) {
     tp.text = TextSpan(
       text: "Test",
       style: TextStyle(
         fontSize: fontSize,
         // fontFamily: fontFamily,
         height: 1,
-        foreground: p,
+        foreground: paintToUse,
       ),
     );
     tp.layout(

--- a/lib/text.dart
+++ b/lib/text.dart
@@ -53,6 +53,7 @@ class PostTextPainter extends CustomPainter {
         fontSize: fontSize,
         // fontFamily: fontFamily,
         height: 1,
+        overflow: (p.style==PaintingStyle.stroke) ? TextOverflow.clip : TextOverflow.ellipsis,
         foreground: p,
       ),
     );


### PR DESCRIPTION
This PR does NOT fix the paint issue, but it changes the offset of the second fill paint so that you can see that the tp.paint() does occur, but it is somehow re-using the results from the first paint operation.  

If you uncomment the `overflow` line of the `TextStyle` you can see that the second paint operation again actually works and uses the correct paint object.