### PR TITLE
add call to TextPainter's  markNeedsLayout() to get the second tp.paint() call to 'work'

### DIFF
--- a/lib/text.dart
+++ b/lib/text.dart
@@ -4,7 +4,6 @@ import 'package:flutter/material.dart';
 
 class PostTextPainter extends CustomPainter {
   final Paint p = Paint();
-  final Paint fillp = Paint();  // create a second paint object for fill
   final Color textColor = Colors.white;
   final double fontSize = 100;
   final TextPainter tp = TextPainter(
@@ -34,25 +33,27 @@ class PostTextPainter extends CustomPainter {
       // draw text stroke
       p.color = Colors.black;
       p.style = PaintingStyle.stroke;
-      p.strokeWidth = 3;
-      drawTextInternal(canvas, size, p);
+      p.strokeWidth = 2;
+      drawTextInternal(canvas, size);
     }
     if (drawBody) {
       // draw text body
-      fillp.color = textColor;
-      fillp.style = PaintingStyle.fill;
-      drawTextInternal(canvas, size, fillp);
+      p.color = textColor;
+      p.style = PaintingStyle.fill;
+      drawTextInternal(canvas, size);
     }
   }
 
-  void drawTextInternal(Canvas canvas, Size size, Paint paintToUse) {
+  static int call=0;
+  void drawTextInternal(Canvas canvas, Size size) {
+    call++;
     tp.text = TextSpan(
       text: "Test",
       style: TextStyle(
         fontSize: fontSize,
         // fontFamily: fontFamily,
         height: 1,
-        foreground: paintToUse,
+        foreground: p,
       ),
     );
     tp.layout(

--- a/lib/text.dart
+++ b/lib/text.dart
@@ -4,7 +4,7 @@ import 'package:flutter/material.dart';
 
 class PostTextPainter extends CustomPainter {
   final Paint p = Paint();
-  final Paint fillp = Paint();
+  final Paint fillp = Paint();  // create a second paint object for fill
   final Color textColor = Colors.white;
   final double fontSize = 100;
   final TextPainter tp = TextPainter(

--- a/lib/text.dart
+++ b/lib/text.dart
@@ -44,9 +44,7 @@ class PostTextPainter extends CustomPainter {
     }
   }
 
-  static int call=0;
   void drawTextInternal(Canvas canvas, Size size) {
-    call++;
     tp.text = TextSpan(
       text: "Test",
       style: TextStyle(
@@ -56,6 +54,14 @@ class PostTextPainter extends CustomPainter {
         foreground: p,
       ),
     );
+    
+    // (This comment from text_painter.dart):
+    //   The TextPainter class should not aggressively invalidate the layout as long
+    //   as `markNeedsLayout` is not called (i.e., the layout cache is still valid).
+    //   See: https://github.com/flutter/flutter/issues/85108
+
+    tp.markNeedsLayout();
+
     tp.layout(
       // minWidth:0,
       minWidth: 200,

--- a/lib/text.dart
+++ b/lib/text.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 
 class PostTextPainter extends CustomPainter {
   final Paint p = Paint();
+  final Paint fillp = Paint();
   final Color textColor = Colors.white;
   final double fontSize = 100;
   final TextPainter tp = TextPainter(
@@ -33,25 +34,25 @@ class PostTextPainter extends CustomPainter {
       // draw text stroke
       p.color = Colors.black;
       p.style = PaintingStyle.stroke;
-      p.strokeWidth = 1;
-      drawTextInternal(canvas, size);
+      p.strokeWidth = 3;
+      drawTextInternal(canvas, size, p);
     }
     if (drawBody) {
       // draw text body
-      p.color = textColor;
-      p.style = PaintingStyle.fill;
-      drawTextInternal(canvas, size);
+      fillp.color = textColor;
+      fillp.style = PaintingStyle.fill;
+      drawTextInternal(canvas, size, fillp);
     }
   }
 
-  void drawTextInternal(Canvas canvas, Size size) {
+  void drawTextInternal(Canvas canvas, Size size, Paint paintToUse) {
     tp.text = TextSpan(
       text: "Test",
       style: TextStyle(
         fontSize: fontSize,
         // fontFamily: fontFamily,
         height: 1,
-        foreground: p,
+        foreground: paintToUse,
       ),
     );
     tp.layout(


### PR DESCRIPTION
You need to call 

`tp.markNeedsLayout()` to force the `tp.paint()` call to actually re-calc everything.  It does not detect the change of the paint object style from stroke to fill.

(i also just changed the strokeWidth so I could see it better)